### PR TITLE
New redis backend calls reset conditionally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### head
+
+* New redis backend instances call `#reset!` conditionally [iamliamnorton]
+
 ### 0.1.8
 
 * Fix issue with redis backend not deleting all job keys on reset [chenkirk]

--- a/lib/allora/backend/redis.rb
+++ b/lib/allora/backend/redis.rb
@@ -41,6 +41,7 @@ module Allora
     #   host:   the hostname of a Redis server
     #   port:   the port number of a Redis server
     #   prefix: a namespace prefix to use
+    #   reset:  delete existing job timing keys in Redis
     #
     # @param [Hash] opts
     #   options for the Redis backend
@@ -48,7 +49,7 @@ module Allora
       @redis  = create_redis(opts)
       @prefix = opts.fetch(:prefix, "allora")
 
-      reset!
+      reset! if opts.fetch(:reset, true)
     end
 
     def reschedule(jobs)


### PR DESCRIPTION
> This is following on from changes in 0.1.8 where job keys were properly
> deleted upon initialization of a new redis backend instances.

> This feature should be configurable as you may not want to reset your
> job keys for each new instance.

> It is called by default to be backward compatible.