### PR TITLE
Allow TTL specification for values in a Redis backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### head
 
+* Redis backend store can specify a TTL [iamliamnorton]
+
 ### 0.1.9
 
 * New redis backend instances call `#reset!` conditionally [iamliamnorton]


### PR DESCRIPTION
Currently job keys are stored in Redis backend without a TTL. Changes in this PR will allow an optional parameter that can specify a TTL for Redis entries.
